### PR TITLE
CRX-2 [MAIN] Add automated release workflow (Focela)

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,0 +1,30 @@
+name: Goreleaser
+
+on:
+  push:
+    tags:
+      - "*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.1"
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,73 @@
+version: 2
+
+project_name: cronx
+
+builds:
+  - id: cronx
+    binary: cronx
+    main: ./cronx.go
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+    env:
+      - CGO_ENABLED=0
+
+archives:
+  - id: cronx
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - README.md
+      - LICENSE
+
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
+  algorithm: sha256
+
+changelog:
+  use: github
+  sort: asc
+  groups:
+    - title: Features
+      regexp: "^.*feat[(\\w)]*:+.*$"
+      order: 0
+    - title: "Bug fixes"
+      regexp: "^.*fix[(\\w)]*:+.*$"
+      order: 1
+    - title: "Enhancements"
+      regexp: "^.*chore[(\\w)]*:+.*$"
+      order: 2
+    - title: "Refactor"
+      regexp: "^.*refactor[(\\w)]*:+.*$"
+      order: 3
+    - title: "Build process updates"
+      regexp: ^.*?(build|ci)(\(.+\))??!?:.+$
+      order: 4
+    - title: "Documentation updates"
+      regexp: ^.*?docs?(\(.+\))??!?:.+$
+      order: 4
+    - title: Others
+      order: 999
+
+release:
+  github:
+    owner: focela
+    name: cronx
+  draft: false
+  prerelease: auto
+  name_template: "{{ .ProjectName }} {{ .Tag }}"
+  header: |
+    ## What's Changed
+  footer: |
+    **Full Changelog**: https://github.com/focela/cronx/compare/{{ .PreviousTag }}...{{ .Tag }}


### PR DESCRIPTION
## What this PR does / why we need it
Adds GitHub Actions workflow for automated releases using GoReleaser with specific Go version 1.25.1 for consistent builds across environments.

## Changes
- Add GoReleaser workflow configuration
- Pin go-version to 1.25.1 for build consistency
- Configure multi-platform builds (linux, windows, darwin)
- Configure multi-architecture builds (amd64, arm64)
- Set up automated release on tag push
- Configure proper permissions for GitHub releases

## Staging PRs
- N/A

## Testing
- N/A

## Notes
- N/A

## Related
- Closes #CRX-2
- Ref: [CRX-2](https://jira.focela.vn/browse/CRX-2)