### PR TITLE
CRX-4 [MAIN] Update program name in usage message (Focela)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * feat(scheduler): add cron job scheduler with signals (#1) (@trants)
 
+### Bug fixes
+
+* fix(usage): update program name in usage message (#4) (@trants)
+
 ### Build process
 
 * ci(goreleaser): add automated release workflow (#2) (@trants)

--- a/cronx.go
+++ b/cronx.go
@@ -102,7 +102,7 @@ func stop(c *cron.Cron, wg *sync.WaitGroup) {
 // scheduler, and handles graceful shutdown on SIGINT or SIGTERM signals.
 func main() {
 	if len(os.Args) < minArgs {
-		fmt.Println("Usage: go-cron [schedule] [command] [args ...]")
+		fmt.Println("Usage: cronx [schedule] [command] [args ...]")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
## What this PR does / why we need it

Update usage message to display 'cronx' instead of 'go-cron' to match actual binary name. This fixes inconsistency between displayed program name and actual executable name.

## Changes
- Change usage message from 'go-cron' to 'cronx' in main function
- Update CHANGELOG.md to include this fix in Bug fixes section

## Staging PRs
- N/A

## Testing
- [x] Manual testing performed
- [x] Usage message displays correct program name
- [x] CHANGELOG.md updated with proper format
- [x] No breaking changes

## Notes
- N/A

## Related
- Closes #CRX-4
- Ref: [CRX-4](https://jira.focela.vn/browse/CRX-4)